### PR TITLE
Update to include sha512 checksum validation

### DIFF
--- a/1.3.1/Dockerfile
+++ b/1.3.1/Dockerfile
@@ -1,13 +1,11 @@
 FROM ubuntu:20.04
 
-#RUN wget http://statics.derasse.ovh/verium-1.3.0/verium-1.3.0-x86_64-linux-gnu.tar.gz
-#RUN wget https://files.vericonomy.com/vrm/verium-1.3.1-x86_64-linux-gnu.tar.gz
-
 ARG VERSION=1.3.1
+ARG CHECKSUM=SHA512SUMS
 
 ENV FILENAME verium-${VERSION}-x86_64-linux-gnu.tar.gz
-#ENV DOWNLOAD_URL http://statics.derasse.ovh/verium-${VERSION}/${FILENAME}
 ENV DOWNLOAD_URL https://files.vericonomy.com/vrm/${FILENAME}
+ENV DOWNLOAD_CHECKSUM https://files.vericonomy.com/vrm/${CHECKSUM}
 
 # Some of this was unabashadly yanked from
 # https://github.com/szyhf/DIDockerfiles/blob/master/bitcoin/alpine/Dockerfile
@@ -22,7 +20,9 @@ RUN apt-get update \
   && apt-get install -y \
   wget \
   && wget $DOWNLOAD_URL \
+  && wget $DOWNLOAD_CHECKSUM \
   && tar xzvf /verium-${VERSION}-x86_64-linux-gnu.tar.gz \
+  && sha512sum --check --ignore-missing SHA512SUMS \
   && mkdir /root/.verium \
   && mv /verium-${VERSION}/bin/* /usr/local/bin/ \
   && rm -rf /verium-${VERSION}/ \

--- a/1.3.1/alpine/Dockerfile
+++ b/1.3.1/alpine/Dockerfile
@@ -1,14 +1,12 @@
 FROM alpine
 
-#Will need to change to appropriate URL when its on vericonomy
-#RUN wget http://statics.derasse.ovh/verium-1.3.0/verium-1.3.0-x86_64-linux-gnu.tar.gz
-
 ARG VERSION=1.3.1
+ARG CHECKSUM=SHA512SUMS
 ARG GLIBC_VERSION=2.29-r0
 
 ENV FILENAME verium-${VERSION}-x86_64-linux-gnu.tar.gz
-#ENV DOWNLOAD_URL http://statics.derasse.ovh/verium-${VERSION}/${FILENAME}
 ENV DOWNLOAD_URL https://files.vericonomy.com/vrm/${FILENAME}
+ENV DOWNLOAD_CHECKSUM https://files.vericonomy.com/vrm/${CHECKSUM}
 
 # Some of this was unabashadly yanked from
 # https://github.com/szyhf/DIDockerfiles/blob/master/bitcoin/alpine/Dockerfile
@@ -30,6 +28,8 @@ RUN apk update \
   && rm -rf /glibc-${GLIBC_VERSION}.apk \
   && rm -rf /glibc-bin-${GLIBC_VERSION}.apk \
   && wget $DOWNLOAD_URL \
+  && wget $DOWNLOAD_CHECKSUM \
+  && cat ${CHECKSUM} | grep ${FILENAME} | sha512sum -c \
   && tar xzvf /verium-${VERSION}-x86_64-linux-gnu.tar.gz \
   && mkdir /root/.verium \
   && mv /verium-${VERSION}/bin/* /usr/local/bin/ \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1 (Verium 1.3.0)
+# 0.2 (Verium 1.3.1)
 
 Used Ubuntu as a base image, cause I like it big.


### PR DESCRIPTION
Verium now releases checksums for the binary files released, so the Docker builds are now following suit and will check the binaries downloaded against the checksums.