### PR TITLE
Wrong verium.conf default setting

### DIFF
--- a/1.3.1/alpine/docker_entrypoint.sh
+++ b/1.3.1/alpine/docker_entrypoint.sh
@@ -35,7 +35,7 @@ rpcallowip=${VRM_RPCALLOWIP:-::/0}
 rpcport=${VRM_RPCPORT:-33987}
 
 # Listen for P2P connections on this TCP port:
-rpcport=${VRM_P2PORT:-33988}
+port=${VRM_P2PORT:-33988}
 
 # Print to console (stdout) so that "docker logs veriumd" prints useful
 # information.

--- a/1.3.1/docker_entrypoint.sh
+++ b/1.3.1/docker_entrypoint.sh
@@ -35,7 +35,7 @@ rpcallowip=${VRM_RPCALLOWIP:-::/0}
 rpcport=${VRM_RPCPORT:-33987}
 
 # Listen for P2P connections on this TCP port:
-rpcport=${VRM_P2PORT:-33988}
+port=${VRM_P2PORT:-33988}
 
 # Print to console (stdout) so that "docker logs veriumd" prints useful
 # information.

--- a/1.3.2/alpine/docker_entrypoint.sh
+++ b/1.3.2/alpine/docker_entrypoint.sh
@@ -35,7 +35,7 @@ rpcallowip=${VRM_RPCALLOWIP:-::/0}
 rpcport=${VRM_RPCPORT:-33987}
 
 # Listen for P2P connections on this TCP port:
-rpcport=${VRM_P2PORT:-33988}
+port=${VRM_P2PORT:-33988}
 
 # Print to console (stdout) so that "docker logs veriumd" prints useful
 # information.

--- a/1.3.2/docker_entrypoint.sh
+++ b/1.3.2/docker_entrypoint.sh
@@ -35,7 +35,7 @@ rpcallowip=${VRM_RPCALLOWIP:-::/0}
 rpcport=${VRM_RPCPORT:-33987}
 
 # Listen for P2P connections on this TCP port:
-rpcport=${VRM_P2PORT:-33988}
+port=${VRM_P2PORT:-33988}
 
 # Print to console (stdout) so that "docker logs veriumd" prints useful
 # information.


### PR DESCRIPTION
When setting the p2p port in verium.conf, it should be referred to by "port" not "rpcport" which is a different thing entirely.